### PR TITLE
Added functions for reading data to TfLint's orchestrator

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,14 +1,79 @@
 package main
 
 import (
+	"bufio"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/plugin"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint-ruleset-template/rules"
 )
 
+func readReccosFile(fileName string) (map[string]map[string]string, error) {
+	reccosMap := map[string]map[string]string{}
+	file, err := os.Open(fileName)
+	if err != nil {
+		return reccosMap, err //System fail
+	}
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		items := strings.Split(line, ":") //items[0] -> AWSID, items[1] -> attributeType items[2] -> attributeValue
+		innerMap, exists := reccosMap[items[0]]
+		if !exists {
+			tempMap := make(map[string]string) // a new map will have to be made as a map with the given AWSID does not exist
+			tempMap[items[1]] = items[2]
+			reccosMap[items[0]] = tempMap
+		} else {
+			innerMap[items[1]] = items[2]
+			reccosMap[items[0]] = innerMap
+		}
+	}
+	return reccosMap, nil
+}
+
+func readTagFile(fileName string) (map[string]string, error) {
+	tagMap := map[string]string{}
+	file, err := os.Open(fileName)
+	if err != nil {
+		return tagMap, err //System fail
+	}
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		items := strings.Split(line, ":") //items[0] -> tag items[1] -> AWSID
+		tagMap[items[0]] = items[1]
+	}
+	return tagMap, nil
+}
+
 func main() {
-	tagToID := make(map[string]string)
-	reccos := make(map[string]map[string]string)
+	reccosFileName := os.Getenv("ReccosMapFile")
+	tagFileName := os.Getenv("TagsMapFile") //both of these environment variables would have been set by the orchestrator
+	currPWD, err := exec.Command("pwd").Output()
+	if err != nil {
+		//Add error log
+		panic(err) //system crash
+	}
+	currPWDStrip := strings.Trim(string(currPWD), "\n") //there is a new line char by defualt that needs to be trimmed
+	reccosFilePath := currPWDStrip + "/" + reccosFileName
+	reccos, errR := readReccosFile(reccosFilePath)
+	if errR != nil {
+		//Add error log
+		panic(errR) //system fail
+	}
+	tagFilePath := currPWDStrip + "/" + tagFileName
+	tagToID, errT := readTagFile(tagFilePath)
+	if errT != nil {
+		//Add err log
+		panic(errT) //system fail
+	}
 	plugin.Serve(&plugin.ServeOpts{
 		RuleSet: &tflint.BuiltinRuleSet{
 			Name:    "template",


### PR DESCRIPTION
Design:

The names of the files that have to be read are being obtained using environment variables. These filenames are relative and would have to be appended to the path of the directory from which tfint would be called (this would be the directory in which the terraform code is present and hence where the orchestrator is being run from)

The files corresponding to these filenames are then being read. the format of the file would be fields separated by ':' i.e. either AWSID->attributeType->attributeValue or tag->AWSID as the case would be. 

The functions that are doing the reading take the filename as arguments and return the mapping and error (or nil if no error) as output. 

The returned maps are then passed onto the rule checker for emitting issues.

Definition of done: Tflilnt's orchestrator should be able to access the files. The maps should be successfully made. These should then be passed forward to the rule checker.
